### PR TITLE
ci(semantic-release): allow initial 0.x versions

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -18,6 +18,7 @@ jobs:
 
       - name: Run go-semantic-release
         id: semrel
-        uses: go-semantic-release/action@v1.0.0
+        uses: go-semantic-release/action@v1.1.0
         with:
           github-token: ${{ secrets.GH_PAT_TOKEN }}
+          allow-initial-deployment-versions: true


### PR DESCRIPTION
Allow 0.x versions in semantic-release to make it easier to start using the
tool during the initial dev phase.